### PR TITLE
rebuild 20231228 for py313

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes


### PR DESCRIPTION
pdfminer.six 20231228 (fix/patch)

**Destination channel:** Snowflake

### Links

- [PKG-6712](https://anaconda.atlassian.net/browse/PKG-6712) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/pdfminer.six-feedstock/pull/2
  - https://github.com/AnacondaRecipes/pdfplumber-feedstock/pull/2

### Explanation of changes:

- enable `py313` build


[PKG-6712]: https://anaconda.atlassian.net/browse/PKG-6712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ